### PR TITLE
Describe iPAddress in subjectAltNames for uaddr

### DIFF
--- a/draft-ietf-nfsv4-rpc-tls.xml
+++ b/draft-ietf-nfsv4-rpc-tls.xml
@@ -626,6 +626,12 @@ Implementors of this specification are advised to read Section 6 of
 for more details on DNS name validation.
 </t>
 <t>
+For services accessed by their network identifiers (netids) and universal
+network addresses (uaddr), the iPAddress subjectAltName SHOULD be present in
+the certificate and must exactly match the address represented by universal
+address.
+</t>
+<t>
 Implementations MAY allow the configuration
 of a set of additional properties of the certificate
 to check for a peer's authorization to communicate


### PR DESCRIPTION
rpc servers accessed by IP address should have iPAddress in subjectAltNames

fixes: #8 